### PR TITLE
fix: TypeScript v6.0 に対応するため tsconfig.json を根本修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@book000/node-utils": "1.24.223",
     "@types/node": "24.13.1",
     "@vercel/ncc": "0.44.0",
-
     "eslint": "10.4.1",
     "eslint-config-standard": "17.1.0",
     "eslint-plugin-import": "2.32.0",
@@ -36,7 +35,7 @@
     "puppeteer-core": "25.1.0",
     "ts-node": "10.9.2",
     "ts-node-dev": "2.0.0",
-    "typescript": "5.9.3",
+    "typescript": "6.0.3",
     "yarn-run-all": "3.1.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,9 +3,11 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["ESNext", "esnext.AsyncIterable", "DOM"],
     "outDir": "./dist",
+    "rootDir": "./src",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo",
     "removeComments": true,
     "esModuleInterop": true,
     "allowJs": true,
@@ -22,11 +24,11 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "experimentalDecorators": true,
-    "baseUrl": ".",
     "newLine": "LF",
     "paths": {
-      "@/*": ["src/*"]
-    }
+      "@/*": ["./src/*"]
+    },
+    "types": ["node"]
   },
   "include": ["src/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3104,10 +3104,10 @@ typescript-eslint@^8.56.0:
     "@typescript-eslint/typescript-estree" "8.60.1"
     "@typescript-eslint/utils" "8.60.1"
 
-typescript@5.9.3:
-  version "5.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+typescript@6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 unbox-primitive@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
## 概要

TypeScript v6.0 アップグレードに伴い、 に発生するビルドエラーを根本的に修正します。

Fixes #2346

## 変更内容

### tsconfig.json

| 変更前 | 変更後 | 理由 |
|--------|--------|------|
| `"moduleResolution": "Node"` | `"moduleResolution": "bundler"` | TypeScript 7.0 で `"Node"` が削除予定。CJS プロジェクトでは `bundler` が推奨 |
| （なし） | `"rootDir": "./src"` | TypeScript 6.0 で `rootDir` のデフォルト推論が変更。明示指定が必要 |
| （なし） | `"tsBuildInfoFile": "./dist/.tsbuildinfo"` | インクリメンタルビルドの出力先を明示 |
| `"baseUrl": "."` | （削除） | TypeScript 7.0 で `baseUrl` が削除予定 |
| `"@/*": ["src/*"]` | `"@/*": ["./src/*"]` | `baseUrl` 削除後、`paths` は tsconfig.json 起点の相対パスに変更 |
| （なし） | `"types": ["node"]` | TypeScript 6.0 で `@types/*` の自動ロードが廃止。`@types/node` を明示 |

### package.json / yarn.lock

- TypeScript を `5.9.3` → `6.0.3` にアップグレード（Renovate PR #2212 と同等）

## 動作確認

- `yarn lint:tsc`（`tsc` 型チェック）: ✅ エラーなし
- `yarn lint`（Prettier + ESLint + TypeScript）: ✅ すべてパス

## 関連

- Issue: #2346
- Renovate PR（TypeScript 6.x アップグレード）: #2212（本 PR のマージにより不要となる）
