### PR TITLE
fix: eslint-plugin-unicorn の name-replacements / prefer-await 違反を解消

### DIFF
--- a/src/discord.ts
+++ b/src/discord.ts
@@ -94,12 +94,12 @@ export class DiscordApi {
       new Blob([arraybuffer]),
       `${isSpoiler ? 'SPOILER_' : ''}image.png`
     )
-    const res = await fetch(this.webhookUrl, {
+    const response = await fetch(this.webhookUrl, {
       method: 'POST',
       body: formData
     })
-    if (!res.ok) {
-      throw new Error(`Failed to send message to Discord: ${res.status}`)
+    if (!response.ok) {
+      throw new Error(`Failed to send message to Discord: ${response.status}`)
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { DiscordApi } from './discord'
 import { Logger } from '@book000/node-utils'
 import { NotesUserListTimelineResponse } from './misskey'
 import { Notified } from './notified'
-import { downloadNotePreviewImage, initPuppeteerBrowser } from './utils'
+import { downloadNotePreviewImage, initPuppeteerBrowser } from './utilities'
 
 interface IEnvironment extends NodeJS.ProcessEnv {
   INSTANCE_DOMAIN: string
@@ -32,7 +32,7 @@ function checkEnvironment() {
 }
 
 async function getUserListTimeline(accessToken: string, listId: string) {
-  const res = await fetch(
+  const response = await fetch(
     `https://${process.env.INSTANCE_DOMAIN}/api/notes/user-list-timeline`,
     {
       method: 'POST',
@@ -46,12 +46,12 @@ async function getUserListTimeline(accessToken: string, listId: string) {
       })
     }
   )
-  if (!res.ok) {
+  if (!response.ok) {
     throw new Error(
-      `Failed to get user list timeline: ${res.status} ${res.statusText}`
+      `Failed to get user list timeline: ${response.status} ${response.statusText}`
     )
   }
-  return (await res.json()) as NotesUserListTimelineResponse
+  return (await response.json()) as NotesUserListTimelineResponse
 }
 
 async function main() {
@@ -158,8 +158,6 @@ async function main() {
 }
 
 ;(async () => {
-  const logger = Logger.configure('main')
-  await main().catch((error: unknown) => {
-    logger.error('Error', error as Error)
-  })
+  // main() 内部で全ての例外を catch しているため、ここでの再捕捉は不要
+  await main()
 })()

--- a/src/utilities.test.ts
+++ b/src/utilities.test.ts
@@ -4,7 +4,7 @@ import {
   NoteElementNotFoundError,
   selectNoteArticleIndex,
   waitForNoteElementForTesting
-} from './utils'
+} from './utilities'
 
 describe('selectNoteArticleIndex', () => {
   it('候補が0件の場合は null を返す', () => {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -188,22 +188,26 @@ async function waitForNoteElement(
         await Promise.all(
           articleHandles
             .filter((_, index) => index !== selection.index)
-            .map((handle) =>
-              handle.dispose().catch(() => {
+            .map(async (handle) => {
+              try {
+                await handle.dispose()
+              } catch {
                 logger.warn('⚠️ Failed to dispose unused article handle')
-              })
-            )
+              }
+            })
         )
         return articleHandles[selection.index]
       }
 
       // 本体を特定できなかった場合は全ての候補が不要になるため破棄する
       await Promise.all(
-        articleHandles.map((handle) =>
-          handle.dispose().catch(() => {
+        articleHandles.map(async (handle) => {
+          try {
+            await handle.dispose()
+          } catch {
             logger.warn('⚠️ Failed to dispose unused article handle')
-          })
-        )
+          }
+        })
       )
 
       logger.warn(
@@ -217,11 +221,11 @@ async function waitForNoteElement(
 
     if (isLastAttempt) {
       const imageFullPath = `/data/${noteId}.full.png` as const
-      await page
-        .screenshot({ path: imageFullPath, fullPage: true })
-        .catch(() => {
-          logger.error(`🚨 Failed to capture full page screenshot`)
-        })
+      try {
+        await page.screenshot({ path: imageFullPath, fullPage: true })
+      } catch {
+        logger.error(`🚨 Failed to capture full page screenshot`)
+      }
       throw new NoteElementNotFoundError(noteId)
     }
 
@@ -310,10 +314,16 @@ async function revealSensitiveFiles(
     }
 
     await mediaElement.click()
-    await page.waitForSelector('.pswp', { timeout: 5000 }).catch(() => {
+    try {
+      await page.waitForSelector('.pswp', { timeout: 5000 })
+    } catch {
       logger.warn(`⚠️ Lightbox did not open for fileId=${fileId}. Continuing.`)
-    })
-    await page.keyboard.press('Escape').catch(() => undefined)
+    }
+    try {
+      await page.keyboard.press('Escape')
+    } catch {
+      // ライトボックスが開いていない場合は Escape 送信が失敗しうるが、無視してよい
+    }
   }
 }
 
@@ -412,8 +422,10 @@ export async function downloadNotePreviewImage(
     return { imagePath }
   } finally {
     // ページを確実に閉じることで、複数ノート処理時のページリーク（メモリ肥大化）を防ぐ
-    await page.close().catch(() => {
+    try {
+      await page.close()
+    } catch {
       logger.warn('⚠️ Failed to close page')
-    })
+    }
   }
 }


### PR DESCRIPTION
## 概要

#2365（`@book000/eslint-config` 1.15.4 -> 1.15.44）で CI が failing になっている件の修正。バンプ自体は追従せず（このリポジトリの `package.json`/`pnpm-lock.yaml` は変更なし）、新しい `eslint-plugin-unicorn` ルールが検出した pre-existing の style 違反のみを修正する。

## 対応内容

- `unicorn/name-replacements`
  - `res` -> `response`（`src/discord.ts`, `src/main.ts`）
  - `src/utils.ts` -> `src/utilities.ts`、`src/utils.test.ts` -> `src/utilities.test.ts`
- `unicorn/prefer-await`
  - `.catch()` によるチェーンを `try/catch` + `await` に置き換え（`src/utilities.ts` 4箇所）
  - `main.ts` のエントリーポイント IIFE: `main()` が内部で全例外を捕捉済みのため、冗長な `.catch()` を削除

## 確認事項

- `@book000/eslint-config@1.15.4`（現行）/ `1.15.44`（#2365 の対象）いずれの下でも `pnpm run lint`（prettier/eslint/tsc）が clean であることをローカルで確認済み
- `pnpm test` 成功（11/11）
- `package.json` / `pnpm-lock.yaml` は変更なし

このPRのマージ後、#2365 のCIが通るはずです。