### PR TITLE
fix: Puppeteer 起動タイムアウトを延長しリトライ処理を追加

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,10 +1,31 @@
-import type { ElementHandle, Page } from 'puppeteer-core'
-import { describe, expect, it, vi, type Mock } from 'vitest'
+import type {
+  default as puppeteer,
+  Browser,
+  ElementHandle,
+  Page
+} from 'puppeteer-core'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock
+} from 'vitest'
 import {
   NoteElementNotFoundError,
+  initPuppeteerBrowser,
   selectNoteArticleIndex,
   waitForNoteElementForTesting
 } from './utils'
+
+const { launchMock } = vi.hoisted(() => ({
+  launchMock: vi.fn<typeof puppeteer.launch>()
+}))
+vi.mock('puppeteer-core', () => ({
+  default: { launch: launchMock }
+}))
 
 describe('selectNoteArticleIndex', () => {
   it('候補が0件の場合は null を返す', () => {
@@ -188,5 +209,65 @@ describe('waitForNoteElement', () => {
     expect(reload).toHaveBeenCalledTimes(2)
     // 本体を特定できなかった場合は全候補を毎試行 dispose する
     expect(sidebar.dispose).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('initPuppeteerBrowser', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    launchMock.mockReset()
+  })
+
+  it('起動に成功すれば即座に Browser を返す', async () => {
+    const browser = {} as Browser
+    launchMock.mockResolvedValueOnce(browser)
+
+    const result = await initPuppeteerBrowser()
+
+    expect(result).toBe(browser)
+    expect(launchMock).toHaveBeenCalledTimes(1)
+    expect(launchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ timeout: 60_000 })
+    )
+  })
+
+  it('一時的な失敗の後に成功すればリトライして Browser を返す', async () => {
+    const browser = {} as Browser
+    launchMock
+      .mockRejectedValueOnce(new Error('timeout'))
+      .mockResolvedValueOnce(browser)
+
+    const promise = initPuppeteerBrowser()
+    // リトライ前の待機（10秒）が経過するまでは次の launch が呼ばれないことを確認する
+    await vi.advanceTimersByTimeAsync(9999)
+    expect(launchMock).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1)
+    const result = await promise
+
+    expect(result).toBe(browser)
+    expect(launchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('最大試行回数まで失敗し続けた場合は最後のエラーを投げる', async () => {
+    const errors = [
+      new Error('1st timeout'),
+      new Error('2nd timeout'),
+      new Error('3rd timeout')
+    ]
+    launchMock
+      .mockRejectedValueOnce(errors[0])
+      .mockRejectedValueOnce(errors[1])
+      .mockRejectedValueOnce(errors[2])
+
+    const promise = initPuppeteerBrowser()
+    const assertion = expect(promise).rejects.toBe(errors[2])
+    await vi.runAllTimersAsync()
+    await assertion
+
+    expect(launchMock).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -82,7 +82,27 @@ export function selectNoteArticleIndex(
   }
 }
 
-export async function initPuppeteerBrowser() {
+const PUPPETEER_LAUNCH_TIMEOUT_MS = 60_000
+const PUPPETEER_LAUNCH_MAX_ATTEMPTS = 3
+// puppeteer は launch 失敗時、CDP 接続未確立のプロセスを最大5秒待って
+// SIGKILL する（BrowserLauncher の graceful shutdown 猶予）。
+// この猶予より短い間隔で再 launch すると、旧プロセスの終了と新プロセスの
+// 起動がリソースを奪い合い、再びタイムアウトを誘発しうるため、
+// 猶予時間より余裕を持たせた値にする
+const PUPPETEER_LAUNCH_RETRY_DELAY_MS = 10_000
+
+/**
+ * Puppeteer（Chromium）を起動する。
+ *
+ * Raspberry Pi 等のリソースが逼迫しやすい実行環境では、他プロセスとの
+ * 競合により Chromium の起動（WS エンドポイント URL の出力）が puppeteer
+ * のデフォルトタイムアウトを超えることがある。そのためタイムアウトを
+ * {@link PUPPETEER_LAUNCH_TIMEOUT_MS} に延長した上で、それでも失敗する
+ * 一時的な事象に備えて最大 {@link PUPPETEER_LAUNCH_MAX_ATTEMPTS} 回まで
+ * リトライする。
+ * @returns 起動した Puppeteer の Browser インスタンス
+ */
+export async function initPuppeteerBrowser(): Promise<Browser> {
   const puppeteerArguments = [
     '--no-sandbox',
     '--disable-setuid-sandbox',
@@ -94,15 +114,37 @@ export async function initPuppeteerBrowser() {
     '--lang=ja',
     '--window-size=1920,1080'
   ]
-  return await puppeteer.launch({
-    headless: true,
-    executablePath: '/usr/bin/chromium-browser',
-    args: puppeteerArguments,
-    defaultViewport: {
-      width: 1920,
-      height: 1080
+  const logger = Logger.configure('initPuppeteerBrowser')
+
+  for (let attempt = 1; attempt <= PUPPETEER_LAUNCH_MAX_ATTEMPTS; attempt++) {
+    try {
+      return await puppeteer.launch({
+        headless: true,
+        executablePath: '/usr/bin/chromium-browser',
+        args: puppeteerArguments,
+        defaultViewport: {
+          width: 1920,
+          height: 1080
+        },
+        timeout: PUPPETEER_LAUNCH_TIMEOUT_MS
+      })
+    } catch (error) {
+      const isLastAttempt = attempt === PUPPETEER_LAUNCH_MAX_ATTEMPTS
+      if (isLastAttempt) {
+        throw error
+      }
+      logger.warn(
+        `🔄 Failed to launch Puppeteer browser. (attempt ${attempt}/${PUPPETEER_LAUNCH_MAX_ATTEMPTS})`,
+        error as Error
+      )
+      await new Promise<void>((resolve) =>
+        setTimeout(resolve, PUPPETEER_LAUNCH_RETRY_DELAY_MS)
+      )
     }
-  })
+  }
+
+  // PUPPETEER_LAUNCH_MAX_ATTEMPTS >= 1 である限りここには到達しない
+  throw new Error('Failed to launch Puppeteer browser')
 }
 
 /**


### PR DESCRIPTION
## 概要

GlitchTip Issue #5（[MISSKEY-LIST-EYES-1](https://glitchtip.orange.amatama.net/main/issues/5)）の対応。

Raspberry Pi 等のリソースが逼迫しやすい環境で、他プロセスとの競合により Chromium の起動が puppeteer のデフォルトタイムアウト（30秒）を超え、`TimeoutError` が発生することがあった（過去4件発生）。

## 変更内容

- `src/utils.ts`: `initPuppeteerBrowser()` の `puppeteer.launch()` タイムアウトを 60000ms に延長
- 起動失敗時に最大3回までリトライする処理を追加（`waitForNoteElement` と同様のパターン）
- リトライ間隔は10秒 — puppeteer が launch 失敗時に CDP 未接続のプロセスを最大5秒待ってから SIGKILL する内部仕様と衝突しないよう、猶予時間より余裕を持たせた
- `src/utils.test.ts`: `puppeteer-core` の `launch` をモックし、成功・リトライ後成功・全試行失敗の3ケースを検証するテストを追加

## 動作確認

- `pnpm lint`: 成功
- `pnpm test`: 14/14 成功
- `pnpm exec prettier --check src`: 成功

## レビュー

ローカル diff モードで `/deep-review` を実施（8観点）。スコア50以上の指摘（Prettier フォーマット違反、リトライ間隔とpuppeteer内部の待機仕様の衝突、テストのアサーション不足など）は全て対応済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R5XhcjJ3br1h9wD85AbWCW